### PR TITLE
fix: fix framebuffer status 36054 crash with iris shader

### DIFF
--- a/src/main/java/com/igrium/craftui/app/AppManager.java
+++ b/src/main/java/com/igrium/craftui/app/AppManager.java
@@ -149,7 +149,7 @@ public final class AppManager {
 
     private static void updateViewportBounds(MinecraftClient client) {
         Window window = client.getWindow();
-        if (currentViewportBounds != null) {
+        if (currentViewportBounds != null && currentViewportBounds.isValid()) {
             window.setFramebufferWidth(currentViewportBounds.width());
             window.setFramebufferHeight(currentViewportBounds.height());
         } else {

--- a/src/main/java/com/igrium/craftui/app/CraftApp.java
+++ b/src/main/java/com/igrium/craftui/app/CraftApp.java
@@ -11,7 +11,17 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract class CraftApp {
 
-    public record ViewportBounds(int x, int y, int width, int height) {}
+    public record ViewportBounds(int x, int y, int width, int height) {
+        /**
+         * For some reason, width and height equal to or less than 1 can cause crashes with
+         * Iris shader enabled. (Cause Framebuffer.Status 36054 - IncompleteAttachment)
+         *
+         * @return True if width and height are greater than 1, false otherwise.
+         */
+        public boolean isValid() {
+            return width > 1 && height > 1;
+        }
+    }
 
     private final UIEvent<Runnable> openEvent = UIEvent.ofRunnable();
 


### PR DESCRIPTION
## Summary

This PR prevents `Framebuffer.Status 36054 (IncompleteAttachment)` crashes that can occur when `ViewportBounds` resolves to small sizes (≤ 1 px), an issue observed with Iris shaders enabled.
It adds a safety check before applying custom viewport bounds and introduces a small helper on `ViewportBounds`.

## Reproducing

**Prereqs**

* **Iris** enabled with any shader pack (e.g. *Complementary Reimagined*)

**Steps**

1. Launch the `TestmodClient` and ensure **Iris** is active with a shader selected.
2. In-game, open chat and run:

   ```
   /apptest open
   ```
3. Observe: the game **crashes**.

**Expected**

* `AppTest` run normally with ImGui and the Viewport rendered.

**Actual**

* Crash with FBO error (`Framebuffer.Status 36054 / IncompleteAttachment`).
```
[01:49:30] [Render thread/ERROR] (Minecraft) Unreported exception thrown!
 java.lang.IllegalStateException: Unexpected error while creating framebuffer: Draw buffers [0, 1] Status: 36054
	at knot/net.irisshaders.iris.targets.RenderTargets.createColorFramebuffer(RenderTargets.java:366) ~[iris-1.8.8+mc1.21.4-64b5720b4b825f21.jar:?]
	at knot/net.irisshaders.iris.pipeline.CompositeRenderer.recalculateSizes(CompositeRenderer.java:247) ~[iris-1.8.8+mc1.21.4-64b5720b4b825f21.jar:?]
	at knot/net.irisshaders.iris.pipeline.IrisRenderingPipeline.beginLevelRendering(IrisRenderingPipeline.java:921) ~[iris-1.8.8+mc1.21.4-64b5720b4b825f21.jar:?]
	at knot/net.minecraft.client.render.WorldRenderer.handler$zpb000$iris$setupPipeline(WorldRenderer.java:5641) ~[minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at knot/net.minecraft.client.render.WorldRenderer.render(WorldRenderer.java) ~[minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at knot/net.minecraft.client.render.GameRenderer.renderWorld(GameRenderer.java:733) ~[minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at knot/net.minecraft.client.render.GameRenderer.render(GameRenderer.java:493) ~[minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at knot/net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1341) ~[minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at knot/net.minecraft.client.MinecraftClient.run(MinecraftClient.java:922) [minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at knot/net.minecraft.client.main.Main.main(Main.java:267) [minecraft-merged-a172fc6613-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.8-v2.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:506) [fabric-loader-0.17.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72) [fabric-loader-0.17.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.17.3.jar:?]
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86) [dev-launch-injector-0.2.1+build.8.jar:?]
```

**Notes**

* Disabling the shader avoids the crash.

## Changes

* **`AppManager.updateViewportBounds(...)`**

  * Apply `currentViewportBounds` **only if** `width > 1` **and** `height > 1`; otherwise fall back to the window size.
* **`CraftApp.ViewportBounds`**

  * Add `boolean isValid()` returning `width > 1 && height > 1`, with Doc explaining the Iris-related failure mode.

---

## Quick Fix (via Mixin)

If you need an immediate workaround while waiting for a library update, you can clamp the framebuffer size with two targeted redirects. This avoids touching the original control flow:  

```java
@Mixin(AppManager.class)
public class AppManagerMixin {

    @Shadow
    @Nullable
    private static CraftApp.ViewportBounds currentViewportBounds;

    @Inject(
            method = "updateViewportBounds(Lnet/minecraft/client/MinecraftClient;)V",
            at = @At("HEAD"),
            cancellable = true
    )
    private static void occamy$fixViewport(MinecraftClient client, CallbackInfo ci) {
        final Window window = client.getWindow();

        int fbW, fbH;
        if (currentViewportBounds != null
                && currentViewportBounds.width() > 1
                && currentViewportBounds.height() > 1) {
            fbW = currentViewportBounds.width();
            fbH = currentViewportBounds.height();
        } else {
            fbW = window.getWidth();
            fbH = window.getHeight();
        }

        window.setFramebufferWidth(fbW);
        window.setFramebufferHeight(fbH);
        client.onResolutionChanged();

        ci.cancel();
    }

}
```
